### PR TITLE
add missing comma to thesaurus

### DIFF
--- a/Umbicosaurus/Umbicosaurus.Demo/App_Plugins/Umbicosaurus/thesaurus.json
+++ b/Umbicosaurus/Umbicosaurus.Demo/App_Plugins/Umbicosaurus/thesaurus.json
@@ -2818,7 +2818,7 @@
   },
   "icon-power": {
     "thesaurus": [
-      "shut down"
+      "shut down",
       "on",
       "off"
     ],


### PR DESCRIPTION
Apart from that, it works on v9.