### PR TITLE
some small updates

### DIFF
--- a/Umbicosaurus/Umbicosaurus.Demo/App_Plugins/Umbicosaurus/thesaurus.json
+++ b/Umbicosaurus/Umbicosaurus.Demo/App_Plugins/Umbicosaurus/thesaurus.json
@@ -3634,7 +3634,11 @@
     "related": []
   },
   "icon-coins-dollar-alt": {
-    "thesaurus": [],
+    "thesaurus": [
+      "money",
+      "us",
+      "usa"
+    ],
     "group": "",
     "related": []
   },
@@ -3804,12 +3808,22 @@
     "related": []
   },
   "icon-coin-dollar": {
-    "thesaurus": [],
+    "thesaurus": [
+      "money",
+      "us",
+      "usa",
+      "paper",
+      "cash"
+    ],
     "group": "",
     "related": []
   },
   "icon-coin-pound": {
-    "thesaurus": [],
+    "thesaurus": [
+      "money",
+      "sterling",
+      "cash"
+    ],
     "group": "",
     "related": []
   },
@@ -3819,12 +3833,18 @@
     "related": []
   },
   "icon-coin": {
-    "thesaurus": [],
+    "thesaurus": [
+      "money",
+      "cash"
+    ],
     "group": "",
     "related": []
   },
   "icon-coins-alt": {
-    "thesaurus": [],
+    "thesaurus": [
+      "money",
+      "cash"
+    ],
     "group": "",
     "related": []
   },
@@ -3938,7 +3958,12 @@
     "related": []
   },
   "icon-coins-dollar": {
-    "thesaurus": [],
+    "thesaurus": [
+      "money",
+      "us",
+      "usa",
+      "cash"
+    ],
     "group": "",
     "related": []
   },
@@ -4069,7 +4094,13 @@
     "related": []
   },
   "icon-dollar-bag": {
-    "thesaurus": [],
+    "thesaurus": [
+      "money",
+      "us",
+      "usa",
+      "cash",
+    "sack"
+    ],
     "group": "",
     "related": []
   },
@@ -4697,7 +4728,13 @@
     "related": []
   },
   "icon-bills-dollar": {
-    "thesaurus": [],
+    "thesaurus": [
+      "money",
+      "us",
+      "usa",
+      "paper",
+      "cash"
+    ],
     "group": "",
     "related": []
   },
@@ -4817,7 +4854,13 @@
     "related": []
   },
   "icon-bill-dollar": {
-    "thesaurus": [],
+    "thesaurus": [
+      "money",
+      "us",
+      "usa",
+      "paper",
+      "cash"
+    ],
     "group": "",
     "related": []
   },


### PR DESCRIPTION
Just done to see how i can help tackle this mammoth task.

if this approach is okay , I might look at ideas and was to block update groups of related icons   with thesaurus terms

all icons with Pound 
UK/uk
money 
currency 
paper
cash 

and then go through that way for coverage, rather than completeness

